### PR TITLE
Re-add previously removed test

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -373,6 +373,15 @@ describe 'pam' do
             next
           end
 
+          if check == 'vas' and v[:osfamily] == 'Debian' and v[:release] == '18.04'
+            it 'should fail' do
+              expect {
+                should contain_class('pam')
+              }.to raise_error(Puppet::Error,/Pam: vas is not supported on #{v[:lsbdistid]} #{v[:release]}/)
+            end
+            next
+          end
+
           v[:files].each do |file|
             group = file[:group] || 'root'
             dirpath = file[:dirpath] || '/etc/pam.d/'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -656,7 +656,7 @@ describe 'pam' do
           end
         end
 
-        if v[:osfamily] == 'Debian' and v[:lsbdistid] == 'Ubuntu' and (v[:release] == '12.04' or v[:release] == '14.04')
+        if v[:osfamily] == 'Debian' and v[:lsbdistid] == 'Ubuntu' and ['12.04', '14.04'].include?(v[:release])
           it { should contain_class('pam::accesslogin') }
           it { should contain_class('pam::limits') }
 


### PR DESCRIPTION
Test ensures that the module will not support VAS with the next version of Ubuntu
without explicity adding necessary code to the module.